### PR TITLE
Fixed player casting, and modified getLocation for entity.

### DIFF
--- a/Granite/src/main/java/org/granitemc/granite/entity/GraniteEntity.java
+++ b/Granite/src/main/java/org/granitemc/granite/entity/GraniteEntity.java
@@ -498,7 +498,7 @@ public class GraniteEntity extends Composite implements Entity {
 
     @Override
     public Location getLocation() {
-        return new Location((double) fieldGet(this, "posX"), (double) fieldGet(this, "posY"), (double) fieldGet(this, "posZ"), (float) fieldGet(this, "rotationYaw"), (float) fieldGet(this, "rotationPitch"));
+        return new Location(getWorld(), (double) fieldGet("posX"), (double) fieldGet("posY"), (double) fieldGet("posZ"), (float) fieldGet("rotationYaw"), (float) fieldGet("rotationPitch"));
     }
 
     @Override

--- a/GraniteAPI/src/main/java/org/granitemc/granite/api/entity/player/Player.java
+++ b/GraniteAPI/src/main/java/org/granitemc/granite/api/entity/player/Player.java
@@ -2,6 +2,7 @@ package org.granitemc.granite.api.entity.player;
 
 import org.granitemc.granite.api.block.Block;
 import org.granitemc.granite.api.block.BlockType;
+import org.granitemc.granite.api.command.CommandSender;
 import org.granitemc.granite.api.chat.ChatComponent;
 import org.granitemc.granite.api.entity.Entity;
 import org.granitemc.granite.api.entity.EntityLivingBase;
@@ -14,7 +15,7 @@ import org.granitemc.granite.api.world.World;
 
 import java.util.UUID;
 
-public interface Player extends EntityLivingBase {
+public interface Player extends CommandSender, EntityLivingBase {
 
     boolean isUsingItem();
 


### PR DESCRIPTION
This fixes a bug where commandSender could not be cast to a player object, also fixes a bug where getting an entity location would throw an NPE and also would not contain the world object. Both fixes have been tested and work.
