### PR TITLE
Fixed a java8 specific causing the building of the project to fail.

### DIFF
--- a/Granite/src/main/java/org/granitemc/granite/reflect/PlayServerComposite.java
+++ b/Granite/src/main/java/org/granitemc/granite/reflect/PlayServerComposite.java
@@ -240,7 +240,7 @@ public class PlayServerComposite extends ProxyComposite {
         addHook(new HookListener() {
             @Override
             public Object activate(Object self, Method method, Method proxyCallback, Hook hook, Object[] args) throws InvocationTargetException, IllegalAccessException {
-                if (method.getParameterCount() == 1 && method.getParameterTypes()[0] == Mappings.getClass("C0EPacketClickWindow")) {
+                if (method.getParameterTypes().length == 1 && method.getParameterTypes()[0] == Mappings.getClass("C0EPacketClickWindow")) {
                     self = self;
                 }
                 return null;


### PR DESCRIPTION
This fix is the same as dfc9b45f3d25f09d8b7458a77fc6fa770c601853 in a different class. As this is a java8 problem should  the project be moved to java8. Supposedly the vanilla server operates best under 8,  which adds more legitimacy to migrating the project.
