### PR TITLE
GranitePluginManager: Fix loading plugins

### DIFF
--- a/src/main/java/org/granitepowered/granite/impl/plugin/GranitePluginManager.java
+++ b/src/main/java/org/granitepowered/granite/impl/plugin/GranitePluginManager.java
@@ -52,7 +52,7 @@ public class GranitePluginManager implements PluginManager {
              public boolean accept(File arg0, String arg1) {
                  return arg1.endsWith(".jar");
              }
-         });
+        });
 
         if (files != null) {
              for (File plugin : files) {
@@ -85,21 +85,17 @@ public class GranitePluginManager implements PluginManager {
                                      plugins.add(pluginContainer);
                                      Granite.instance.getLogger().info("Loaded {} ({})!", pluginContainer.getName(), pluginContainer.getVersion());
                                  }
-
                              } catch (ClassNotFoundException e) {
                                  e.printStackTrace();
                              }
 
                          }
                      }
-
                  } catch (IOException e) {
                      e.printStackTrace();
                  }
-
              }
-         }
-
+        }
     }
 
     @Override


### PR DESCRIPTION
Also, string formatting was a bit wrong (slf4j formatting uses {} for anchors and not %s, %d, etc.)

Currently:

```
[Granite Startup] INFO Granite - Loading jarfile plugins/%s
Exception in thread "Granite Startup" [11:49:41] [Granite Startup/INFO]: [STDERR]@.(Throwable.java:748): java.lang.NullPointerException
[11:49:41] [Granite Startup/INFO]: [STDERR]@.(Throwable.java:748):  at org.granitepowered.granite.impl.plugin.GranitePluginManager.loadPlugins(GranitePluginManager.java:85)
[11:49:41] [Granite Startup/INFO]: [STDERR]@.(Throwable.java:748):  at org.granitepowered.granite.GraniteStartupThread.run(GraniteStartupThread.java:90)
```

After this commit:

```
[Granite Startup] INFO Granite - Loading jarfile plugins/LWC-Sponge-0.0.1-SNAPSHOT.jar
[Granite Startup] INFO Granite - Loaded LWC (0.0.1-SNAPSHOT)!
```

I wasn't sure what to do with `Collection<PluginContainer> plugins` because it wasn't ever being initialized. I just initialized it to an `ArrayList`.
