### PR TITLE
Initial Guice support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>3.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.7</version>
@@ -163,6 +169,9 @@
                                     <include>com.github.kevinsawicki:http-request</include>
                                     <include>org.slf4j:*</include>
                                     <include>com.google.code.gson:gson</include>
+                                    <include>com.google.inject:guice</include>
+                                    <include>javax.inject:javax.inject</include>
+                                    <include>aopalliance:aopalliance</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/src/main/java/org/granitepowered/granite/Granite.java
+++ b/src/main/java/org/granitepowered/granite/Granite.java
@@ -25,6 +25,8 @@ package org.granitepowered.granite;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.inject.Injector;
+
 import javassist.ClassPool;
 import org.granitepowered.granite.impl.GraniteGameRegistry;
 import org.granitepowered.granite.impl.GraniteServer;
@@ -41,29 +43,44 @@ import org.granitepowered.granite.utils.json.TextActionJson;
 import org.slf4j.Logger;
 import org.spongepowered.api.GameRegistry;
 import org.spongepowered.api.plugin.PluginManager;
+import org.spongepowered.api.service.ServiceManager;
 import org.spongepowered.api.service.SimpleServiceManager;
+import org.spongepowered.api.service.command.CommandService;
 import org.spongepowered.api.service.command.SimpleCommandService;
 import org.spongepowered.api.service.event.EventManager;
 
 import java.io.File;
 
+import javax.inject.Inject;
+
 public class Granite {
     public static Granite instance;
 
+    // Not injected directly; initialization is done after classes are rewritten
+    GraniteServer server;
+
+    final GranitePluginManager pluginManager;
+    final GraniteGameRegistry gameRegistry;
+    final GraniteEventManager eventManager;
+    final CommandService commandService;
+    final ServiceManager serviceManager;
+
     String version;
     ServerConfig serverConfig;
-    GraniteServer server;
-    GranitePluginManager pluginManager;
-    GraniteGameRegistry gameRegistry;
-    GraniteEventManager eventManager;
     ClassPool classPool;
-    SimpleCommandService commandService;
-    SimpleServiceManager serviceManager;
     Logger logger;
     Gson gson;
     File classesDir;
 
-    public Granite() {
+    @Inject
+    public Granite(GranitePluginManager pluginManager,
+                   GraniteGameRegistry gameRegistry,
+                   GraniteEventManager eventManager) {
+        this.pluginManager = pluginManager;
+        this.gameRegistry = gameRegistry;
+        this.eventManager = eventManager;
+        this.serviceManager = new SimpleServiceManager(pluginManager);
+        this.commandService = new SimpleCommandService(pluginManager);
         version = "UNKNOWN";
     }
 
@@ -122,11 +139,11 @@ public class Granite {
         return eventManager;
     }
 
-    public SimpleServiceManager getServiceManager() {
+    public ServiceManager getServiceManager() {
         return serviceManager;
     }
 
-    public SimpleCommandService getCommandService() {
+    public CommandService getCommandService() {
         return commandService;
     }
 }

--- a/src/main/java/org/granitepowered/granite/impl/guice/GraniteGuiceModule.java
+++ b/src/main/java/org/granitepowered/granite/impl/guice/GraniteGuiceModule.java
@@ -1,0 +1,161 @@
+/*
+ * License (MIT)
+ *
+ * Copyright (c) 2014 Granite Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.granitepowered.granite.impl.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.Scopes;
+
+import org.granitepowered.granite.Granite;
+import org.granitepowered.granite.impl.GraniteGameRegistry;
+import org.granitepowered.granite.impl.GraniteServer;
+import org.granitepowered.granite.impl.plugin.GranitePluginManager;
+import org.granitepowered.granite.impl.service.event.GraniteEventManager;
+import org.spongepowered.api.Game;
+import org.spongepowered.api.GameRegistry;
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.plugin.PluginManager;
+import org.spongepowered.api.service.config.ConfigDir;
+import org.spongepowered.api.service.event.EventManager;
+
+import java.io.File;
+import java.lang.annotation.Annotation;
+
+import javax.inject.Inject;
+
+public class GraniteGuiceModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        PluginScope pluginScope = new PluginScope();
+
+        ConfigDir sharedConfigDir = new ConfigDirAnnotation(true);
+        ConfigDir privateConfigDir = new ConfigDirAnnotation(false);
+
+        bind(Granite.class).in(Scopes.SINGLETON);
+
+        bindScope(PluginScoped.class, pluginScope);
+        bind(PluginScope.class).toInstance(pluginScope);
+
+        bind(Game.class).toProvider(GraniteServerProvider.class).in(Scopes.SINGLETON);
+        bind(PluginManager.class).to(GranitePluginManager.class).in(Scopes.SINGLETON);
+        bind(GameRegistry.class).to(GraniteGameRegistry.class).in(Scopes.SINGLETON);
+        bind(EventManager.class).to(GraniteEventManager.class).in(Scopes.SINGLETON);
+
+        bind(PluginContainer.class).toProvider(PluginContainerProvider.class).in(PluginScoped.class);
+        bind(File.class).annotatedWith(sharedConfigDir).toProvider(GlobalPluginDataDirProvider.class).in(Scopes.SINGLETON);
+        bind(File.class).annotatedWith(privateConfigDir).toProvider(PluginDataDirProvider.class).in(PluginScoped.class);
+    }
+
+    private static class ConfigDirAnnotation implements ConfigDir {
+
+        private boolean isShared;
+
+        public ConfigDirAnnotation(boolean isShared) {
+            this.isShared = isShared;
+        }
+
+        @Override
+        public boolean sharedRoot() {
+            return isShared;
+        }
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return ConfigDir.class;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || !(o instanceof ConfigDir)) {
+                return false;
+            }
+
+            ConfigDir that = (ConfigDir) o;
+            return sharedRoot() == that.sharedRoot();
+        }
+
+        @Override
+        public int hashCode() {
+            return (127 * "sharedRoot".hashCode()) ^ Boolean.valueOf(sharedRoot()).hashCode();
+        }
+
+    }
+
+    /**
+     * Provides GraniteServer. This is used instead of <code>to(GraniteServer.class)</code>
+     * because otherwise, it would be immediately loaded by Guice and then class rewriting
+     * would fail.
+     */
+    private static class GraniteServerProvider implements Provider<Game> {
+        @Override
+        public Game get() {
+            return new GraniteServer();
+        }
+    }
+
+    private static class PluginContainerProvider implements Provider<PluginContainer> {
+
+        private final PluginScope scope;
+
+        @Inject
+        public PluginContainerProvider(PluginScope scope) {
+            this.scope = scope;
+        }
+
+        @Override
+        public PluginContainer get() {
+            return scope.getInstance(Key.get(PluginContainer.class));
+        }
+
+    }
+
+    private static class GlobalPluginDataDirProvider implements Provider<File> {
+        @Override
+        public File get() {
+            return Granite.getInstance().getServerConfig().getPluginDataDirectory();
+        }
+    }
+
+    private static class PluginDataDirProvider implements Provider<File> {
+
+        private final PluginContainer container;
+
+        @Inject
+        public PluginDataDirProvider(PluginContainer container) {
+            this.container = container;
+        }
+
+        @Override
+        public File get() {
+            return new File(Granite.getInstance().getServerConfig().getPluginDataDirectory(), container.getId() + "/");
+        }
+    }
+
+}

--- a/src/main/java/org/granitepowered/granite/impl/guice/PluginScope.java
+++ b/src/main/java/org/granitepowered/granite/impl/guice/PluginScope.java
@@ -1,0 +1,96 @@
+/*
+ * License (MIT)
+ *
+ * Copyright (c) 2014 Granite Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.granitepowered.granite.impl.guice;
+
+import com.google.common.collect.Maps;
+import com.google.inject.Key;
+import com.google.inject.OutOfScopeException;
+import com.google.inject.Provider;
+import com.google.inject.Scope;
+
+import org.spongepowered.api.plugin.PluginContainer;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class PluginScope implements Scope {
+
+    private final ThreadLocal<Map<Key<?>, Object>> values = new ThreadLocal<>();
+
+    public void enter(PluginContainer container) {
+        checkState(values.get() == null, "A scoping block is already in progress");
+        values.set(Maps.<Key<?>, Object>newHashMap());
+        seed(PluginContainer.class, container);
+    }
+
+    public void exit() {
+        checkState(values.get() != null, "No scoping block in progress");
+        values.remove();
+    }
+
+    public <T> void seed(Key<T> key, T value) {
+        Map<Key<?>, Object> scopedObjects = getScopedObjectMap(key);
+        checkState(!scopedObjects.containsKey(key), "A value for the key %s was already seeded in this scope. Old value: %s New value: %s", key, scopedObjects.get(key), value);
+        scopedObjects.put(key, value);
+    }
+
+    public <T> void seed(Class<T> clazz, T value) {
+        seed(Key.get(clazz), value);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getInstance(Key<T> key) {
+        Map<Key<?>, Object> scopedObjects = getScopedObjectMap(key);
+        return (T) scopedObjects.get(key);
+    }
+
+    public <T> Provider<T> scope(final Key<T> key, final Provider<T> unscoped) {
+        return new Provider<T>() {
+            public T get() {
+                Map<Key<?>, Object> scopedObjects = getScopedObjectMap(key);
+
+                @SuppressWarnings("unchecked")
+                T current = (T) scopedObjects.get(key);
+
+                if (current == null && !scopedObjects.containsKey(key)) {
+                    current = unscoped.get();
+
+                    scopedObjects.put(key, current);
+                }
+
+                return current;
+            }
+        };
+    }
+
+    private <T> Map<Key<?>, Object> getScopedObjectMap(Key<T> key) {
+        Map<Key<?>, Object> scopedObjects = values.get();
+        if (scopedObjects == null) {
+            throw new OutOfScopeException("Cannot access " + key + " outside of a scoping block");
+        }
+        return scopedObjects;
+    }
+
+}

--- a/src/main/java/org/granitepowered/granite/impl/guice/PluginScoped.java
+++ b/src/main/java/org/granitepowered/granite/impl/guice/PluginScoped.java
@@ -1,0 +1,38 @@
+/*
+ * License (MIT)
+ *
+ * Copyright (c) 2014 Granite Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the
+ * Software without restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.granitepowered.granite.impl.guice;
+
+import com.google.inject.ScopeAnnotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@ScopeAnnotation
+public @interface PluginScoped {
+
+}


### PR DESCRIPTION
Hello!

This includes the initial changes for Guice injections. It didn't seem right to use Guice for just plugins themselves, so I've begun integrating Guice a bit more with Granite itself although it's very laissez-faire at the moment.
##### What is not yet supported (should be straightforward to add, just not done yet.):
- Plugin-specific `Logger`
- `@DefaultConfig`

As for what _is_ supported right now, `@ConfigDir` and any non plugin-local values (such as `Game`).
##### Overview of structural changes
- `GraniteStartupThread` load order and initialization has been modified to better support Guice. I might change it more in the future because it's still a bit messy.
  - `pluginManager.loadPlugins()` is now done _after_ everything is initialized & injected (but before the first plugin events are sent) so that plugin classes are not loaded (and then injected) with a `Game (GraniteServer)` instance that has not yet been rewritten yet.
    - could likely be moved back if needed by ensuring `bootstrapPlugin` is called _after_ all classes are rewritten. (otherwise if a plugin wants a `Game` instance, they'll get a `GraniteServer` instance that is not rewritten => crashes the server!)
- `PluginScope` is quite a bit different from Sponge's at the moment, but might be changed at some point to have the exact same behaviour. Much of it is based off of [official documentation](https://github.com/google/guice/wiki/CustomScopes).
- A lot of the local members inside `Granite` have been made final & replaced with a constructor tagged with `@Inject`. **This is automatically constructed by Guice (see [GraniteServerThread#111](https://github.com/Hidendra/Granite/blob/5ccd329a6e7c05d1033543a02a57db3b203c3b00/src/main/java/org/granitepowered/granite/GraniteStartupThread.java#L111)).** The idea is that eventually `@Inject` should be preferred over directly creating instances where possible. 
- `SimpleCommandService` cannot be auto injected at the moment for some reason. It seems to cause duplicate `PluginManager` instances to be created (Sponge's Forge impl does the same thing: creates the instance directly). I will have to look into this more because it should work with Guice without any issues (or so I think).
##### How do plugins use Guice?

If there's any confusion about _how_ to use Guice: Guice injects instances _it creates & manages_ into your constructor (not for plugins however), local fields, or setter methods tagged with `@Inject`.

Any [bind()s](https://github.com/Hidendra/Granite/blob/5ccd329a6e7c05d1033543a02a57db3b203c3b00/src/main/java/org/granitepowered/granite/impl/guice/GraniteGuiceModule.java#L57) can be injected. So if I wanted a `Game` or `GameRegistry`, no problem. The binds with `annotatedWith` binds signify that they require that annotation _and_ `@Inject`.

Example:

```
@Inject
private Game game;
```

or:

```
@Inject
public void setGame(Game game) {
    this.game = game;
}
```

Both will achieve the same thing in the end.

LWC [makes use of these](https://github.com/Hidendra/LWC/blob/5.0/mods/sponge/src/main/java/org/getlwc/sponge/SpongePlugin.java#L66) so feel free to use it as a reference plugin. LWC currently runs great with this PR.

Let me know if any of you have any questions. I should be able to better explain exactly _what_ this does over IRC or something if any of you are still really confused about Guice :smile: 
