### PR TITLE
Add DedicatedServer to MinecraftUtils/composites so that console commands work

### DIFF
--- a/src/main/java/org/granitepowered/granite/utils/MinecraftUtils.java
+++ b/src/main/java/org/granitepowered/granite/utils/MinecraftUtils.java
@@ -28,6 +28,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import org.granitepowered.granite.Granite;
 import org.granitepowered.granite.composite.Composite;
+import org.granitepowered.granite.impl.GraniteServer;
 import org.granitepowered.granite.impl.block.GraniteBlockProperty;
 import org.granitepowered.granite.impl.block.GraniteBlockState;
 import org.granitepowered.granite.impl.block.GraniteBlockType;
@@ -63,6 +64,7 @@ public class MinecraftUtils {
             .put(Mappings.getClass("EntityPlayerMP"), GranitePlayer.class)
             .put(Mappings.getClass("BlockState"), GraniteBlockState.class)
             .put(Mappings.getClass("Block"), GraniteBlockType.class)
+            .put(Mappings.getClass("DedicatedServer"), GraniteServer.class)
             .put(Mappings.getClass("ItemBlock"), GraniteItemBlock.class)
             .put(Mappings.getClass("ItemStack"), GraniteItemStack.class)
             .put(Mappings.getClass("Item"), GraniteItemType.class)


### PR DESCRIPTION
Currently the server seems to crash with this when using a console command:

```
[12:07:44] [Server thread/ERROR]: Encountered an unexpected exception
java.lang.NullPointerException
  at org.granitepowered.granite.utils.MinecraftUtils.wrap(MinecraftUtils.java:81) ~[classes/:?]
  at org.granitepowered.granite.bytecode.classes.CommandHandlerClass$1.handle(CommandHandlerClass.java:55) ~[classes/:?]
  at org.granitepowered.granite.bytecode.BytecodeClass$ProxyHandler.preHandle(BytecodeClass.java:362) ~[classes/:?]
  at ab.a(SourceFile) ~[graniteClasses570668301615902894/:?]
  at pp.aN(SourceFile:332) ~[graniteClasses570668301615902894/:?]
  at pp.A(SourceFile:300) ~[graniteClasses570668301615902894/:?]
  at net.minecraft.server.MinecraftServer.z(SourceFile:532) ~[graniteClasses570668301615902894/:?]
  at net.minecraft.server.MinecraftServer.run(SourceFile:448) [graniteClasses570668301615902894/:?]
  at java.lang.Thread.run(Thread.java:745) [?:1.7.0_67]
```

Adding `DedicatedServer` to the composites field seems to make commands work normally:

```
help
[12:09:07] [Server thread/INFO]: --- Showing help page 1 of 9 (/help <page>) ---
[12:09:07] [Server thread/INFO]: /achievement <give|take> <stat_name|*> [player]
[12:09:07] [Server thread/INFO]: /ban <name> [reason ...]
[12:09:07] [Server thread/INFO]: /ban-ip <address|name> [reason ...]
[12:09:07] [Server thread/INFO]: /banlist [ips|players]
[...]
```
