### PR TITLE
CommandHandler: Call the SimpleCommandService/onCommandEvent listener di...

### DIFF
--- a/src/main/java/org/granitepowered/granite/bytecode/classes/CommandHandlerClass.java
+++ b/src/main/java/org/granitepowered/granite/bytecode/classes/CommandHandlerClass.java
@@ -28,6 +28,7 @@ import org.granitepowered.granite.Granite;
 import org.granitepowered.granite.bytecode.BytecodeClass;
 import org.granitepowered.granite.impl.event.message.GraniteCommandEvent;
 import org.granitepowered.granite.mc.MCInterface;
+import org.spongepowered.api.service.command.SimpleCommandService;
 import org.spongepowered.api.util.command.CommandSource;
 
 import java.util.Arrays;
@@ -56,6 +57,16 @@ public class CommandHandlerClass extends BytecodeClass {
 
                 GraniteCommandEvent event = new GraniteCommandEvent(commandName, StringUtils.join(commandArgs, " "), sender);
                 Granite.getInstance().getEventManager().post(event);
+
+                if (!event.isCancelled()) {
+                    SimpleCommandService dispatcher = (SimpleCommandService) Granite.getInstance().getCommandService();
+
+                    // TODO while SimpleCommandService does listen for CommandEvent, what's the
+                    // expected way to actually register it? It requires a valid plugin instance,
+                    // so is the server software expected to be an implicit plugin itself?
+                    event.isCancellable = true;
+                    dispatcher.onCommandEvent(event);
+                }
 
                 if (!event.isCancelled()) {
                     return callback.invokeParent(args);


### PR DESCRIPTION
… directly so that plugins registering commands via the dispatcher get the command.

This is more to discuss, but it works so feel free to merge anyway if you think this is okay.

Sponge's SimpleCommandService [listens for CommandEvent](https://github.com/SpongePowered/SpongeAPI/blob/master/src/main/java/org/spongepowered/api/service/command/SimpleCommandService.java#L73) but _how should this be registered_?

The event manager requires a valid plugin instance, so should the Granite server be an implicit plugin by itself?

Right now it's just calling that event handler directly which works but is of course a _bit_ of a hack :grin: 
