### PR TITLE
Implement guice plugin injections for Logger & DefaultConfig.

### DIFF
--- a/src/main/java/org/granitepowered/granite/impl/guice/GraniteGuiceModule.java
+++ b/src/main/java/org/granitepowered/granite/impl/guice/GraniteGuiceModule.java
@@ -25,23 +25,29 @@ package org.granitepowered.granite.impl.guice;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Key;
-import com.google.inject.Provider;
 import com.google.inject.Scopes;
+
 import org.granitepowered.granite.Granite;
 import org.granitepowered.granite.impl.GraniteGameRegistry;
 import org.granitepowered.granite.impl.GraniteServer;
 import org.granitepowered.granite.impl.plugin.GranitePluginManager;
 import org.granitepowered.granite.impl.service.event.GraniteEventManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.GameRegistry;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.plugin.PluginManager;
 import org.spongepowered.api.service.config.ConfigDir;
+import org.spongepowered.api.service.config.DefaultConfig;
 import org.spongepowered.api.service.event.EventManager;
+import org.spongepowered.api.util.config.ConfigFile;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.lang.annotation.Annotation;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
 
 public class GraniteGuiceModule extends AbstractModule {
 
@@ -49,6 +55,7 @@ public class GraniteGuiceModule extends AbstractModule {
     protected void configure() {
         PluginScope pluginScope = new PluginScope();
 
+        DefaultConfig pluginConfig = new ConfigFileAnnotation(true);
         ConfigDir sharedConfigDir = new ConfigDirAnnotation(true);
         ConfigDir privateConfigDir = new ConfigDirAnnotation(false);
 
@@ -61,15 +68,123 @@ public class GraniteGuiceModule extends AbstractModule {
         bind(PluginManager.class).to(GranitePluginManager.class).in(Scopes.SINGLETON);
         bind(GameRegistry.class).to(GraniteGameRegistry.class).in(Scopes.SINGLETON);
         bind(EventManager.class).to(GraniteEventManager.class).in(Scopes.SINGLETON);
+        bind(File.class).annotatedWith(sharedConfigDir).toProvider(GlobalPluginDataDirProvider.class).in(Scopes.SINGLETON);
 
         bind(PluginContainer.class).toProvider(PluginContainerProvider.class).in(PluginScoped.class);
-        bind(File.class).annotatedWith(sharedConfigDir).toProvider(GlobalPluginDataDirProvider.class).in(Scopes.SINGLETON);
+        bind(Logger.class).toProvider(PluginLoggerProvider.class).in(PluginScoped.class);
         bind(File.class).annotatedWith(privateConfigDir).toProvider(PluginDataDirProvider.class).in(PluginScoped.class);
+        bind(File.class).annotatedWith(pluginConfig).toProvider(PluginConfigFileProvider.class).in(PluginScoped.class);
+        bind(ConfigFile.class).annotatedWith(pluginConfig).toProvider(PluginHoconConfigProvider.class).in(PluginScoped.class);
+    }
+
+    /**
+     * Provides GraniteServer. This is used instead of <code>to(GraniteServer.class)</code>
+     * because otherwise it would be immediately loaded by Guice and then class rewriting
+     * would fail.
+     */
+    private static class GraniteServerProvider implements Provider<Game> {
+
+        @Override
+        public Game get() {
+            return new GraniteServer();
+        }
+
+    }
+
+    private static class PluginContainerProvider implements Provider<PluginContainer> {
+
+        private final PluginScope scope;
+
+        @Inject
+        public PluginContainerProvider(PluginScope scope) {
+            this.scope = scope;
+        }
+
+        @Override
+        public PluginContainer get() {
+            return scope.getInstance(Key.get(PluginContainer.class));
+        }
+
+    }
+
+    private static class PluginLoggerProvider implements Provider<Logger> {
+
+        private final PluginContainer container;
+
+        @Inject
+        public PluginLoggerProvider(PluginContainer container) {
+            this.container = container;
+        }
+
+        @Override
+        public Logger get() {
+            return LoggerFactory.getLogger(container.getId());
+        }
+
+    }
+
+    private static class PluginConfigFileProvider implements Provider<File> {
+
+        private final PluginContainer container;
+        private final File configDir;
+
+        @Inject
+        public PluginConfigFileProvider(PluginContainer container, @ConfigDir(sharedRoot = true) File configDir) {
+            this.container = container;
+            this.configDir = configDir;
+        }
+
+        @Override
+        public File get() {
+            return new File(configDir, container.getId() + ".conf");
+        }
+
+    }
+
+    private static class PluginHoconConfigProvider implements Provider<ConfigFile> {
+
+        private final File configFile;
+
+        @Inject
+        public PluginHoconConfigProvider(@DefaultConfig(sharedRoot = true) File configFile) {
+            this.configFile = configFile;
+        }
+
+        @Override
+        public ConfigFile get() {
+            return ConfigFile.parseFile(configFile);
+        }
+
+    }
+
+    private static class GlobalPluginDataDirProvider implements Provider<File> {
+
+        @Override
+        public File get() {
+            return Granite.getInstance().getServerConfig().getPluginDataDirectory();
+        }
+
+    }
+
+    private static class PluginDataDirProvider implements Provider<File> {
+
+        private final PluginContainer container;
+
+        @Inject
+        public PluginDataDirProvider(PluginContainer container) {
+            this.container = container;
+        }
+
+        @Override
+        public File get() {
+            return new File(Granite.getInstance().getServerConfig().getPluginDataDirectory(), container.getId() + "/");
+        }
+
     }
 
     private static class ConfigDirAnnotation implements ConfigDir {
 
-        private boolean isShared;
+        private final boolean isShared;
 
         public ConfigDirAnnotation(boolean isShared) {
             this.isShared = isShared;
@@ -106,54 +221,44 @@ public class GraniteGuiceModule extends AbstractModule {
 
     }
 
-    /**
-     * Provides GraniteServer. This is used instead of <code>to(GraniteServer.class)</code>
-     * because otherwise, it would be immediately loaded by Guice and then class rewriting
-     * would fail.
-     */
-    private static class GraniteServerProvider implements Provider<Game> {
-        @Override
-        public Game get() {
-            return new GraniteServer();
-        }
-    }
+    private static class ConfigFileAnnotation implements DefaultConfig {
 
-    private static class PluginContainerProvider implements Provider<PluginContainer> {
+        private final boolean shared;
 
-        private final PluginScope scope;
-
-        @Inject
-        public PluginContainerProvider(PluginScope scope) {
-            this.scope = scope;
+        public ConfigFileAnnotation(boolean isShared) {
+            this.shared = isShared;
         }
 
         @Override
-        public PluginContainer get() {
-            return scope.getInstance(Key.get(PluginContainer.class));
-        }
-
-    }
-
-    private static class GlobalPluginDataDirProvider implements Provider<File> {
-        @Override
-        public File get() {
-            return Granite.getInstance().getServerConfig().getPluginDataDirectory();
-        }
-    }
-
-    private static class PluginDataDirProvider implements Provider<File> {
-
-        private final PluginContainer container;
-
-        @Inject
-        public PluginDataDirProvider(PluginContainer container) {
-            this.container = container;
+        public boolean sharedRoot() {
+            return shared;
         }
 
         @Override
-        public File get() {
-            return new File(Granite.getInstance().getServerConfig().getPluginDataDirectory(), container.getId() + "/");
+        public Class<? extends Annotation> annotationType() {
+            return DefaultConfig.class;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || !(o instanceof DefaultConfig)) {
+                return false;
+            }
+
+            DefaultConfig that = (DefaultConfig) o;
+
+            return sharedRoot() == that.sharedRoot();
+        }
+
+        @Override
+        public int hashCode() {
+            return (127 * "sharedRoot".hashCode()) ^ Boolean.valueOf(sharedRoot()).hashCode();
+        }
+
     }
+
 
 }


### PR DESCRIPTION
This also includes some cleanup & reordering for the guice module so that fields are better grouped.

This means that plugins can now add fields like these inside of their class w/ `@Plugin` (they will be automatically populated!):

```
@Inject
private Logger logger;

@Inject
@DefaultConfig(shared = true)
private File configFile;

@Inject
@DefaultConfig(sharedRoot = true)
private ConfigFile config;
```

This completes support for all of the Guice injections that Sponge (Forge) currently supports :smile:

LWC makes use of `@Inject` for `Game`, `Logger`, and `@ConfigDir`. If you want to test, here's [a build](https://artifacts.getlwc.org/Hidendra/LWC/235/235.1/mods/sponge/target/LWC-Sponge-5.0.0-SNAPSHOT.jar) and [source plugin class file](https://github.com/Hidendra/LWC/blob/5.0/mods/sponge/src/main/java/org/getlwc/sponge/SpongePlugin.java#L67).
