### PR TITLE
Changes to implement GameStoppingEvent and GameStoppedEvent in SpongeForge.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "SpongeCommon"]
 	path = SpongeCommon
-	url = https://github.com/SpongePowered/SpongeCommon.git
+	url = https://github.com/JBYoshi/SpongeCommon.git

--- a/src/main/java/org/spongepowered/server/SpongeVanilla.java
+++ b/src/main/java/org/spongepowered/server/SpongeVanilla.java
@@ -35,7 +35,6 @@ import org.spongepowered.api.GameState;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.Order;
-import org.spongepowered.api.event.SpongeEventFactoryUtils;
 import org.spongepowered.api.event.game.state.GameAboutToStartServerEvent;
 import org.spongepowered.api.event.game.state.GameConstructionEvent;
 import org.spongepowered.api.event.game.state.GameInitializationEvent;
@@ -43,7 +42,6 @@ import org.spongepowered.api.event.game.state.GameLoadCompleteEvent;
 import org.spongepowered.api.event.game.state.GamePostInitializationEvent;
 import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
 import org.spongepowered.api.event.game.state.GameStartingServerEvent;
-import org.spongepowered.api.event.game.state.GameStateEvent;
 import org.spongepowered.api.event.game.state.GameStoppedServerEvent;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.service.ProviderExistsException;
@@ -104,9 +102,9 @@ public final class SpongeVanilla implements PluginContainer {
 
             SpongeImpl.getLogger().info("Loading plugins...");
             ((VanillaPluginManager) this.game.getPluginManager()).loadPlugins();
-            postState(GameConstructionEvent.class, GameState.CONSTRUCTION);
+            SpongeImpl.postState(GameConstructionEvent.class, GameState.CONSTRUCTION);
             SpongeImpl.getLogger().info("Initializing plugins...");
-            postState(GamePreInitializationEvent.class, GameState.PRE_INITIALIZATION);
+            SpongeImpl.postState(GamePreInitializationEvent.class, GameState.PRE_INITIALIZATION);
 
             checkState(Class.forName("org.spongepowered.api.entity.ai.task.AbstractAITask").getSuperclass()
                     .equals(SpongeEntityAICommonSuperclass.class));
@@ -122,7 +120,7 @@ public final class SpongeVanilla implements PluginContainer {
 
     public void initialize() {
         SpongeImpl.getRegistry().init();
-        postState(GameInitializationEvent.class, GameState.INITIALIZATION);
+        SpongeImpl.postState(GameInitializationEvent.class, GameState.INITIALIZATION);
 
         if (!this.game.getServiceManager().provide(PermissionService.class).isPresent()) {
             try {
@@ -138,11 +136,11 @@ public final class SpongeVanilla implements PluginContainer {
         SpongeImpl.getRegistry().postInit();
         SpongeDataManager.getInstance().completeRegistration();
 
-        postState(GamePostInitializationEvent.class, GameState.POST_INITIALIZATION);
+        SpongeImpl.postState(GamePostInitializationEvent.class, GameState.POST_INITIALIZATION);
 
         SpongeImpl.getLogger().info("Successfully loaded and initialized plugins.");
 
-        postState(GameLoadCompleteEvent.class, GameState.LOAD_COMPLETE);
+        SpongeImpl.postState(GameLoadCompleteEvent.class, GameState.LOAD_COMPLETE);
     }
 
     @Listener(order = Order.PRE)
@@ -183,11 +181,6 @@ public final class SpongeVanilla implements PluginContainer {
     @Override
     public Optional<Object> getInstance() {
         return Optional.of(this);
-    }
-
-    public void postState(Class<? extends GameStateEvent> type, GameState state) {
-        ((VanillaGame) SpongeImpl.getGame()).setState(state);
-        this.game.getEventManager().post(SpongeEventFactoryUtils.createState(type, this.game));
     }
 
 }

--- a/src/main/java/org/spongepowered/server/VanillaGame.java
+++ b/src/main/java/org/spongepowered/server/VanillaGame.java
@@ -29,7 +29,6 @@ import net.minecraft.world.storage.SaveFormatOld;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.GameDictionary;
-import org.spongepowered.api.GameState;
 import org.spongepowered.api.Platform;
 import org.spongepowered.api.event.EventManager;
 import org.spongepowered.api.network.ChannelRegistrar;
@@ -47,8 +46,6 @@ import javax.inject.Singleton;
 @Singleton
 public class VanillaGame extends SpongeGame {
 
-    private GameState state = GameState.CONSTRUCTION;
-
     @Inject
     public VanillaGame(Platform platform, PluginManager pluginManager, EventManager eventManager, SpongeGameRegistry gameRegistry,
             ServiceManager serviceManager, TeleportHelper teleportHelper, Logger logger) {
@@ -62,16 +59,7 @@ public class VanillaGame extends SpongeGame {
 
     @Override
     public GameDictionary getGameDictionary() {
-        throw new NotImplementedException("TODO");
-    }
-
-    @Override
-    public GameState getState() {
-        return this.state;
-    }
-
-    public void setState(GameState state) {
-        this.state = state;
+        return VanillaGameDictionary.getInstance();
     }
 
     @Override

--- a/src/main/java/org/spongepowered/server/mixin/server/MixinDedicatedServer.java
+++ b/src/main/java/org/spongepowered/server/mixin/server/MixinDedicatedServer.java
@@ -38,6 +38,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.common.SpongeImpl;
 import org.spongepowered.common.scheduler.SpongeScheduler;
 import org.spongepowered.server.SpongeVanilla;
 
@@ -72,13 +73,13 @@ public abstract class MixinDedicatedServer extends MinecraftServer {
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/dedicated/DedicatedServer;loadAllWorlds"
             + "(Ljava/lang/String;Ljava/lang/String;JLnet/minecraft/world/WorldType;Ljava/lang/String;)V", shift = At.Shift.BY, by = -24))
     public void callServerAboutToStart(CallbackInfoReturnable<Boolean> ci) {
-        SpongeVanilla.INSTANCE.postState(GameAboutToStartServerEvent.class, GameState.SERVER_ABOUT_TO_START);
+        SpongeImpl.postState(GameAboutToStartServerEvent.class, GameState.SERVER_ABOUT_TO_START);
     }
 
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/dedicated/DedicatedServer;loadAllWorlds"
             + "(Ljava/lang/String;Ljava/lang/String;JLnet/minecraft/world/WorldType;Ljava/lang/String;)V", shift = At.Shift.AFTER))
     public void callServerStarting(CallbackInfoReturnable<Boolean> ci) {
-        SpongeVanilla.INSTANCE.postState(GameStartingServerEvent.class, GameState.SERVER_STARTING);
+        SpongeImpl.postState(GameStartingServerEvent.class, GameState.SERVER_STARTING);
     }
 
     @Inject(method = "updateTimeLightAndEntities", at = @At("RETURN"))

--- a/src/main/java/org/spongepowered/server/mixin/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/server/mixin/server/MixinMinecraftServer.java
@@ -41,9 +41,7 @@ import org.spongepowered.api.event.SpongeEventFactory;
 import org.spongepowered.api.event.cause.Cause;
 import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.event.game.state.GameStartedServerEvent;
-import org.spongepowered.api.event.game.state.GameStoppedEvent;
 import org.spongepowered.api.event.game.state.GameStoppedServerEvent;
-import org.spongepowered.api.event.game.state.GameStoppingEvent;
 import org.spongepowered.api.event.game.state.GameStoppingServerEvent;
 import org.spongepowered.api.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -80,20 +78,18 @@ public abstract class MixinMinecraftServer {
     @Inject(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;addFaviconToStatusResponse"
             + "(Lnet/minecraft/network/ServerStatusResponse;)V", shift = At.Shift.AFTER))
     public void callServerStarted(CallbackInfo ci) {
-        SpongeVanilla.INSTANCE.postState(GameStartedServerEvent.class, GameState.SERVER_STARTED);
+        SpongeImpl.postState(GameStartedServerEvent.class, GameState.SERVER_STARTED);
     }
 
     @Inject(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;finalTick(Lnet/minecraft/crash/CrashReport;)V",
             ordinal = 0, shift = At.Shift.BY, by = -9))
     public void callServerStopping(CallbackInfo ci) {
-        SpongeVanilla.INSTANCE.postState(GameStoppingServerEvent.class, GameState.SERVER_STOPPING);
+        SpongeImpl.postState(GameStoppingServerEvent.class, GameState.SERVER_STOPPING);
     }
 
     @Inject(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;systemExitNow()V"))
     public void callServerStopped(CallbackInfo ci) {
-        SpongeVanilla.INSTANCE.postState(GameStoppedServerEvent.class, GameState.SERVER_STOPPED);
-        SpongeVanilla.INSTANCE.postState(GameStoppingEvent.class, GameState.GAME_STOPPING);
-        SpongeVanilla.INSTANCE.postState(GameStoppedEvent.class, GameState.GAME_STOPPED);
+        SpongeImpl.postState(GameStoppedServerEvent.class, GameState.SERVER_STOPPED);
     }
 
     @Inject(method = "addFaviconToStatusResponse", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
[SpongeCommon PR](https://github.com/SpongePowered/SpongeCommon/pull/284) | [SpongeForge PR](https://github.com/SpongePowered/SpongeForge/pull/425) | **SpongeVanilla PR**

## IMPORTANT NOTE FOR MERGING
I've been having problems with Git and symlinked submodules, so I did not include the SpongeCommon ref bump. Please make sure to add it when you merge this.

----------

- Moves `GameStoppingEvent` and `GameStoppedEvent` firing in `DedicatedServer` from SpongeVanilla to SpongeCommon.
- Moves `SpongeVanilla.postState()` to `SpongeImpl`.
- Moves `SpongeModGame.getState()`/`VanillaGame.getState()` and `SpongeModGame.setState()`/`VanillaGame.setState()` to `SpongeGame`.