### PR TITLE
Handle movement of common_at.cfg

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "SpongeCommon"]
 	path = SpongeCommon
-	url = https://github.com/SpongePowered/SpongeCommon.git
+	url = https://github.com/kenzierocks/SpongeCommon.git

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,9 @@ jar {
     }
 }
 
-shadowJar {
+ats += 'vanilla_at.cfg'
+
+ext.shadowConfig = {
     // Include production log4j2.xml
     rename 'log4j2_prod.xml', 'log4j2.xml'
 
@@ -77,3 +79,5 @@ shadowJar {
         include dependency('jline:jline')
     }
 }
+shadowJar shadowConfig
+shadowDeobfJar shadowConfig

--- a/src/main/java/org/spongepowered/server/launch/VanillaServerTweaker.java
+++ b/src/main/java/org/spongepowered/server/launch/VanillaServerTweaker.java
@@ -119,7 +119,7 @@ public final class VanillaServerTweaker implements ITweaker {
         }
 
         logger.debug("Applying access transformer...");
-        Launch.blackboard.put("vanilla.at", new URL[]{ getResource("common_at.cfg"), getResource("vanilla_at.cfg") });
+        Launch.blackboard.put("vanilla.at", new URL[]{ getResource("META-INF/common_at.cfg"), getResource("META-INF/vanilla_at.cfg") });
         loader.registerTransformer("org.spongepowered.server.launch.transformer.AccessTransformer");
 
         logger.debug("Initializing Mixin environment...");


### PR DESCRIPTION
https://github.com/SpongePowered/SpongeCommon/pull/289 requires that I move the `common_at.cfg` for `FMLAT` (not used here). This updates SpongeVanilla to handle that. [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/453).