### PR TITLE
Add 'require' argument to injectors

### DIFF
--- a/src/main/java/org/spongepowered/server/mixin/crash/MixinCrashReport.java
+++ b/src/main/java/org/spongepowered/server/mixin/crash/MixinCrashReport.java
@@ -39,7 +39,7 @@ public abstract class MixinCrashReport {
 
     @Shadow private CrashReportCategory theReportCategory;
 
-    @Inject(method = "populateEnvironment", at = @At("RETURN"))
+    @Inject(method = "populateEnvironment", at = @At("RETURN"), require = 1)
     private void onPopulateEnvironment(CallbackInfo ci) {
         this.theReportCategory.addCrashSectionCallable("Plugins", () -> {
             StringBuilder result = new StringBuilder(64);

--- a/src/main/java/org/spongepowered/server/mixin/entity/MixinEntity.java
+++ b/src/main/java/org/spongepowered/server/mixin/entity/MixinEntity.java
@@ -42,7 +42,7 @@ import javax.annotation.Nullable;
 public abstract class MixinEntity {
     @Nullable private NBTTagCompound customEntityData;
 
-    @Inject(method = "<init>(Lnet/minecraft/world/World;)V", at = @At("RETURN"), remap = false)
+    @Inject(method = "<init>(Lnet/minecraft/world/World;)V", at = @At("RETURN"), remap = false, require = 1)
     public void onConstructed(World world, CallbackInfo ci) {
         final Entity spongeEntity = (Entity) this;
         SpongeImpl.postEvent(SpongeEventFactory.createConstructEntityEventPost(Cause.of(NamedCause.source(world)), spongeEntity,
@@ -50,7 +50,7 @@ public abstract class MixinEntity {
     }
 
     @Inject(method = "readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;readEntityFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V"))
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;readEntityFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V"), require = 1)
     public void preReadFromNBTInject(NBTTagCompound tagCompound, CallbackInfo ci) {
         if (tagCompound.hasKey("ForgeData")) {
             this.customEntityData = tagCompound.getCompoundTag("ForgeData");
@@ -58,7 +58,7 @@ public abstract class MixinEntity {
     }
 
     @Inject(method = "writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;writeEntityToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V"))
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;writeEntityToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V"), require = 1)
     public void preWriteToNBTInject(NBTTagCompound tagCompound, CallbackInfo ci) {
         if (this.customEntityData != null) {
             tagCompound.setTag("ForgeData", this.customEntityData);

--- a/src/main/java/org/spongepowered/server/mixin/entity/living/MixinEntityLivingBase.java
+++ b/src/main/java/org/spongepowered/server/mixin/entity/living/MixinEntityLivingBase.java
@@ -60,7 +60,7 @@ public abstract class MixinEntityLivingBase extends Entity {
         super(null);
     }
 
-    @Inject(method = "onDeath", at = @At("HEAD"))
+    @Inject(method = "onDeath", at = @At("HEAD"), require = 1)
     private void callDestructEntityLivingBase(DamageSource source, CallbackInfo ci) {
         callDestructEntityEventDeath(source, ci);
     }

--- a/src/main/java/org/spongepowered/server/mixin/entity/player/MixinEntityPlayer.java
+++ b/src/main/java/org/spongepowered/server/mixin/entity/player/MixinEntityPlayer.java
@@ -97,7 +97,7 @@ public abstract class MixinEntityPlayer extends EntityLivingBase implements Enti
         }
     }
 
-    @Inject(method = "setSpawnPoint", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "setSpawnPoint", at = @At("HEAD"), cancellable = true, require = 1)
     public void onSetSpawnPoint(BlockPos pos, boolean forced, CallbackInfo ci) {
         if (this.dimension != 0) {
             setSpawnChunk(pos, forced, this.dimension);
@@ -105,7 +105,7 @@ public abstract class MixinEntityPlayer extends EntityLivingBase implements Enti
         }
     }
 
-    @Inject(method = "clonePlayer", at = @At("RETURN"))
+    @Inject(method = "clonePlayer", at = @At("RETURN"), require = 1)
     public void onClonePlayerEnd(EntityPlayer oldPlayer, boolean respawnFromEnd, CallbackInfo ci) {
         this.spawnChunkMap = ((IMixinEntityPlayer) oldPlayer).getSpawnChunkMap();
         this.spawnForcedMap = ((IMixinEntityPlayer) oldPlayer).getSpawnForcedMap();
@@ -167,7 +167,7 @@ public abstract class MixinEntityPlayer extends EntityLivingBase implements Enti
         return new Transaction<>(itemSnapshot, itemSnapshot.copy());
     }
 
-    @Inject(method = "setItemInUse", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/EntityPlayer;itemInUse:Lnet/minecraft/item/ItemStack;", opcode = Opcodes.PUTFIELD), cancellable = true)
+    @Inject(method = "setItemInUse", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/EntityPlayer;itemInUse:Lnet/minecraft/item/ItemStack;", opcode = Opcodes.PUTFIELD), cancellable = true, require = 1)
     public void onSetItemInUse(net.minecraft.item.ItemStack stack, int duration, CallbackInfo ci) {
         // Handle logic on our own
         ci.cancel();
@@ -185,7 +185,7 @@ public abstract class MixinEntityPlayer extends EntityLivingBase implements Enti
         }
     }
 
-    @Inject(method = "onUpdate", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/EntityPlayer;itemInUseCount:I", opcode = Opcodes.GETFIELD))
+    @Inject(method = "onUpdate", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/EntityPlayer;itemInUseCount:I", opcode = Opcodes.GETFIELD), require = 1)
     public void callUseItemStackTick(CallbackInfo ci) {
         UseItemStackEvent.Tick event = SpongeEventFactory.createUseItemStackEventTick(Cause.of(NamedCause.source(this)),
                 this.itemInUseCount, this.itemInUseCount, createTransaction(this.itemInUse));
@@ -222,7 +222,7 @@ public abstract class MixinEntityPlayer extends EntityLivingBase implements Enti
         return (net.minecraft.item.ItemStack) event.getItemStackResult().getFinal().createStack();
     }
 
-    @Inject(method = "trySleep", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "trySleep", at = @At("HEAD"), cancellable = true, require = 1)
     public void onTrySleep(BlockPos bedPos, CallbackInfoReturnable<EntityPlayer.EnumStatus> ci) {
         SleepingEvent.Pre event = SpongeEventFactory.createSleepingEventPre(Cause.of(NamedCause.source(this)),
                 ((org.spongepowered.api.world.World) this.worldObj).createSnapshot(bedPos.getX(), bedPos.getY(), bedPos.getZ()), this);

--- a/src/main/java/org/spongepowered/server/mixin/entity/player/MixinEntityPlayerMP.java
+++ b/src/main/java/org/spongepowered/server/mixin/entity/player/MixinEntityPlayerMP.java
@@ -42,14 +42,14 @@ public abstract class MixinEntityPlayerMP extends MixinEntityLivingBase {
     @Shadow private NetHandlerPlayServer playerNetServerHandler;
     private static final AttributeKey<Boolean> FML_MARKER = AttributeKey.valueOf("fml:hasMarker");
 
-    @Inject(method = "onDeath", at = @At("HEAD"))
+    @Inject(method = "onDeath", at = @At("HEAD"), require = 1)
     private void callDestructEntityPlayerMP(DamageSource source, CallbackInfo ci) {
         callDestructEntityEventDeath(source, ci);
     }
 
 
     @Redirect(method = "onDeath", at = @At(value = "INVOKE",
-            target = "Lnet/minecraft/world/GameRules;getGameRuleBooleanValue(Ljava/lang/String;)Z", ordinal = 0))
+            target = "Lnet/minecraft/world/GameRules;getGameRuleBooleanValue(Ljava/lang/String;)Z", ordinal = 0), require = 1)
     public boolean onGetGameRules(GameRules gameRules, String gameRule) {
         return false; // Suppress death messages since this is handled together with the event calling
     }

--- a/src/main/java/org/spongepowered/server/mixin/server/MixinConsoleHandler.java
+++ b/src/main/java/org/spongepowered/server/mixin/server/MixinConsoleHandler.java
@@ -45,7 +45,7 @@ public abstract class MixinConsoleHandler {
     @Shadow(remap = false, aliases = {"field_72428_a", "this$0"})
     private DedicatedServer server;
 
-    @Inject(method = "run", at = @At("HEAD"), cancellable = true, remap = false)
+    @Inject(method = "run", at = @At("HEAD"), cancellable = true, remap = false, require = 1)
     public void onRun(CallbackInfo ci) {
         final ConsoleReader reader = TerminalConsoleAppender.getReader();
 

--- a/src/main/java/org/spongepowered/server/mixin/server/MixinDedicatedServer.java
+++ b/src/main/java/org/spongepowered/server/mixin/server/MixinDedicatedServer.java
@@ -49,13 +49,13 @@ public abstract class MixinDedicatedServer extends MinecraftServer {
     }
 
     @Inject(method = "startServer", at = @At(value = "INVOKE_STRING", target = "Lorg/apache/logging/log4j/Logger;info(Ljava/lang/String;)V",
-            args = "ldc=Loading properties", remap = false))
+            args = "ldc=Loading properties", remap = false), require = 1)
     public void onServerLoad(CallbackInfoReturnable<Boolean> ci) throws Exception {
         SpongeVanilla.INSTANCE.preInitialize();
     }
 
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/dedicated/DedicatedServer;setConfigManager"
-            + "(Lnet/minecraft/server/management/ServerConfigurationManager;)V", shift = At.Shift.BY, by = -7))
+            + "(Lnet/minecraft/server/management/ServerConfigurationManager;)V", shift = At.Shift.BY, by = -7), require = 1)
     public void onServerInitialize(CallbackInfoReturnable<Boolean> ci) {
         SpongeVanilla.INSTANCE.initialize();
 
@@ -67,18 +67,18 @@ public abstract class MixinDedicatedServer extends MinecraftServer {
     }
 
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/dedicated/DedicatedServer;loadAllWorlds"
-            + "(Ljava/lang/String;Ljava/lang/String;JLnet/minecraft/world/WorldType;Ljava/lang/String;)V", shift = At.Shift.BY, by = -24))
+            + "(Ljava/lang/String;Ljava/lang/String;JLnet/minecraft/world/WorldType;Ljava/lang/String;)V", shift = At.Shift.BY, by = -24), require = 1)
     public void callServerAboutToStart(CallbackInfoReturnable<Boolean> ci) {
         SpongeVanilla.INSTANCE.onServerAboutToStart();
     }
 
     @Inject(method = "startServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/dedicated/DedicatedServer;loadAllWorlds"
-            + "(Ljava/lang/String;Ljava/lang/String;JLnet/minecraft/world/WorldType;Ljava/lang/String;)V", shift = At.Shift.AFTER))
+            + "(Ljava/lang/String;Ljava/lang/String;JLnet/minecraft/world/WorldType;Ljava/lang/String;)V", shift = At.Shift.AFTER), require = 1)
     public void callServerStarting(CallbackInfoReturnable<Boolean> ci) {
         SpongeVanilla.INSTANCE.onServerStarting();
     }
 
-    @Inject(method = "updateTimeLightAndEntities", at = @At("RETURN"))
+    @Inject(method = "updateTimeLightAndEntities", at = @At("RETURN"), require = 1)
     public void onTick(CallbackInfo ci) {
         SpongeScheduler.getInstance().tickSyncScheduler();
     }

--- a/src/main/java/org/spongepowered/server/mixin/server/MixinMinecraftServer.java
+++ b/src/main/java/org/spongepowered/server/mixin/server/MixinMinecraftServer.java
@@ -73,17 +73,17 @@ public abstract class MixinMinecraftServer {
     private Hashtable<Integer, long[]> worldTickTimes = new Hashtable<Integer, long[]>();
 
     @Inject(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;finalTick(Lnet/minecraft/crash/CrashReport;)V",
-            ordinal = 0, shift = At.Shift.BY, by = -9))
+            ordinal = 0, shift = At.Shift.BY, by = -9), require = 1)
     public void callServerStopping(CallbackInfo ci) {
         SpongeVanilla.INSTANCE.onServerStopping();
     }
 
-    @Inject(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;systemExitNow()V"))
+    @Inject(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;systemExitNow()V"), require = 1)
     public void callServerStopped(CallbackInfo ci) throws Exception {
         SpongeVanilla.INSTANCE.onServerStopped();
     }
 
-    @Inject(method = "addFaviconToStatusResponse", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "addFaviconToStatusResponse", at = @At("HEAD"), cancellable = true, require = 1)
     public void onAddFaviconToStatusResponse(ServerStatusResponse response, CallbackInfo ci) {
         // Don't load favicon twice
         if (response.getFavicon() != null) {
@@ -92,7 +92,7 @@ public abstract class MixinMinecraftServer {
     }
 
     @Inject(method = "stopServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/WorldServer;flush()V"),
-            locals = LocalCapture.CAPTURE_FAILHARD)
+            locals = LocalCapture.CAPTURE_FAILHARD, require = 1)
     public void callWorldUnload(CallbackInfo ci, int i, WorldServer worldserver) {
         SpongeImpl.postEvent(SpongeEventFactory.createUnloadWorldEvent(Cause.of(NamedCause.source(this)), (World) worldserver));
     }

--- a/src/main/java/org/spongepowered/server/mixin/server/management/MixinItemInWorldManager.java
+++ b/src/main/java/org/spongepowered/server/mixin/server/management/MixinItemInWorldManager.java
@@ -53,7 +53,7 @@ public abstract class MixinItemInWorldManager {
     @Shadow public net.minecraft.world.World theWorld;
     @Shadow public EntityPlayerMP thisPlayerMP;
 
-    @Inject(method = "onBlockClicked", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "onBlockClicked", at = @At("HEAD"), cancellable = true, require = 1)
     public void onOnBlockClicked(BlockPos pos, EnumFacing side, CallbackInfo ci) {
         Location<World> location = new Location<>((World) this.theWorld, VecHelper.toVector(pos));
         InteractBlockEvent.Primary event = SpongeEventFactory.createInteractBlockEventPrimary(Cause.of(NamedCause.source(this.thisPlayerMP)),

--- a/src/main/java/org/spongepowered/server/mixin/tileentity/MixinTileEntity.java
+++ b/src/main/java/org/spongepowered/server/mixin/tileentity/MixinTileEntity.java
@@ -41,14 +41,14 @@ public abstract class MixinTileEntity implements TileEntity, IMixinTileEntity {
 
     @Nullable private NBTTagCompound customEntityData;
 
-    @Inject(method = "readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("RETURN"))
+    @Inject(method = "readFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("RETURN"), require = 1)
     public void endReadFromNBTInject(NBTTagCompound tagCompound, CallbackInfo ci) {
         if (tagCompound.hasKey("ForgeData")) {
             this.customEntityData = tagCompound.getCompoundTag("ForgeData");
         }
     }
 
-    @Inject(method = "writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("RETURN"))
+    @Inject(method = "writeToNBT(Lnet/minecraft/nbt/NBTTagCompound;)V", at = @At("RETURN"), require = 1)
     public void endWriteToNBTInject(NBTTagCompound tagCompound, CallbackInfo ci) {
         if (this.customEntityData != null) {
             tagCompound.setTag("ForgeData", this.customEntityData);

--- a/src/main/java/org/spongepowered/server/mixin/world/MixinChunk.java
+++ b/src/main/java/org/spongepowered/server/mixin/world/MixinChunk.java
@@ -41,13 +41,13 @@ public abstract class MixinChunk {
 
     @Shadow private World worldObj;
 
-    @Inject(method = "onChunkLoad", at = @At("RETURN"))
+    @Inject(method = "onChunkLoad", at = @At("RETURN"), require = 1)
     public void postChunkLoad(CallbackInfo ci) {
         SpongeImpl.postEvent(SpongeEventFactory.createLoadChunkEvent(Cause.of(NamedCause.source(this.worldObj)),
                 (org.spongepowered.api.world.Chunk) this));
     }
 
-    @Inject(method = "onChunkUnload", at = @At("RETURN"))
+    @Inject(method = "onChunkUnload", at = @At("RETURN"), require = 1)
     public void postChunkUnload(CallbackInfo ci) {
         SpongeImpl.postEvent(SpongeEventFactory.createUnloadChunkEvent(Cause.of(NamedCause.source(this.worldObj)),
                 (org.spongepowered.api.world.Chunk) this));

--- a/src/main/java/org/spongepowered/server/mixin/world/MixinWorldServer.java
+++ b/src/main/java/org/spongepowered/server/mixin/world/MixinWorldServer.java
@@ -53,14 +53,14 @@ public abstract class MixinWorldServer extends World {
         super(saveHandlerIn, info, providerIn, profilerIn, client);
     }
 
-    @Inject(method = "<init>", at = @At(value = "RETURN"))
+    @Inject(method = "<init>", at = @At(value = "RETURN"), require = 1)
     public void onConstructed(MinecraftServer server, ISaveHandler saveHandlerIn, WorldInfo info, int dimensionId, Profiler profilerIn,
             CallbackInfo ci) {
         VanillaDimensionManager.setWorld(dimensionId, (WorldServer) (Object) this);
     }
 
     @Inject(method = "newExplosion", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/Explosion;doExplosionA()V"),
-            locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
+            locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true, require = 1)
     public void callWorldOnExplosionEvent(Entity entityIn, double x, double y, double z, float strength, boolean isFlaming, boolean isSmoking,
             CallbackInfoReturnable<Explosion> cir, Explosion explosion) {
         final ExplosionEvent.Pre event = SpongeEventFactory.createExplosionEventPre(((IMixinExplosion) explosion).createCause(),

--- a/src/main/java/org/spongepowered/server/mixin/world/gen/MixinChunkProviderServer.java
+++ b/src/main/java/org/spongepowered/server/mixin/world/gen/MixinChunkProviderServer.java
@@ -60,7 +60,7 @@ public abstract class MixinChunkProviderServer {
     }
 
     @Inject(method = "unloadQueuedChunks", at = @At(value = "INVOKE_ASSIGN", target = "Ljava/util/List;remove(Ljava/lang/Object;)Z", remap = false),
-            cancellable = true)
+            cancellable = true, require = 1)
     public void onUnloadQueuedChunks(CallbackInfoReturnable<Boolean> cir) {
         if (this.loadedChunks.size() == 0 && !VanillaDimensionManager.shouldLoadSpawn(this.worldObj.provider.getDimensionId())){
             VanillaDimensionManager.unloadWorld(this.worldObj.provider.getDimensionId());

--- a/src/main/java/org/spongepowered/server/mixin/world/storage/MixinSaveHandler.java
+++ b/src/main/java/org/spongepowered/server/mixin/world/storage/MixinSaveHandler.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 
 @Mixin(value = SaveHandler.class, priority = 1001)
 public abstract class MixinSaveHandler {
-    @Inject(method = "loadWorldInfo", at = @At(value = "RETURN", ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
+    @Inject(method = "loadWorldInfo", at = @At(value = "RETURN", ordinal = 0), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true, require = 1)
     public void onLoadWorldInfoBeforeReturn0(CallbackInfoReturnable<WorldInfo> cir, File file1, NBTTagCompound nbttagcompound,
             NBTTagCompound nbttagcompound1) throws IOException {
         final WorldInfo info = new WorldInfo(nbttagcompound1);
@@ -48,7 +48,7 @@ public abstract class MixinSaveHandler {
         cir.setReturnValue(info);
     }
 
-    @Inject(method = "loadWorldInfo", at = @At(value = "RETURN", ordinal = 1), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
+    @Inject(method = "loadWorldInfo", at = @At(value = "RETURN", ordinal = 1), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true, require = 1)
     public void onLoadWorldInfoBeforeReturn1(CallbackInfoReturnable<WorldInfo> cir, File file1, NBTTagCompound nbttagcompound,
             NBTTagCompound nbttagcompound1) throws IOException {
         final WorldInfo info = new WorldInfo(nbttagcompound1);


### PR DESCRIPTION
[SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/415) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/491) | SpongeVanilla

This is the corresponding SpongeVanilla PR for the SpongeCommon one.

Notable changes:

1. Removed Vanilla MixinNetHandlerPlayServer#onDisconnectHandler. The exact same code is in SpongeCommon
2. Commented out Vanilla MixinNetHandlerPlayServer#onActivateBlockOrUseItem. It's already redirected in Common, so this won't work. @Minecrell: Which parts of the logic need to be moved to SpongeCommon?