### PR TITLE
Add the SpongeAPI dependency to the annotation processor.

### DIFF
--- a/src/main/java/org/spongepowered/server/VanillaPlatform.java
+++ b/src/main/java/org/spongepowered/server/VanillaPlatform.java
@@ -24,7 +24,6 @@
  */
 package org.spongepowered.server;
 
-import static org.spongepowered.common.SpongeImpl.API_ID;
 import static org.spongepowered.common.SpongeImpl.ECOSYSTEM_ID;
 
 import com.google.inject.Inject;

--- a/src/main/java/org/spongepowered/server/guice/VanillaGuiceModule.java
+++ b/src/main/java/org/spongepowered/server/guice/VanillaGuiceModule.java
@@ -74,7 +74,7 @@ public class VanillaGuiceModule extends AbstractModule {
         bind(Logger.class).toInstance(this.logger);
 
         bind(PluginContainer.class).annotatedWith(named(SpongeImpl.ECOSYSTEM_ID)).toInstance(this.instance);
-        bind(PluginContainer.class).annotatedWith(named(SpongeImpl.API_ID)).to(SpongeApiContainer.class).in(Scopes.SINGLETON);
+        bind(PluginContainer.class).annotatedWith(named(Platform.API_ID)).to(SpongeApiContainer.class).in(Scopes.SINGLETON);
         bind(PluginContainer.class).annotatedWith(named(SpongeImpl.GAME_ID)).to(MinecraftPluginContainer.class).in(Scopes.SINGLETON);
 
         bind(Game.class).to(VanillaGame.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1214) | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/687) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/622) | **SpongeVanilla**

Allows SpongePowered/Ore#95 to be added without giving (most) plugin developers any additional work. This uses a dependency version range, so it will work with any SpongeAPI version that's guaranteed to be compatible.
