### PR TITLE
Update SpongeGradle to fix the build script.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ buildscript {
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
         classpath 'gradle.plugin.net.minecrell:licenser:0.3'
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
-        classpath 'gradle.plugin.org.spongepowered:spongegradle:0.7'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+        classpath 'gradle.plugin.org.spongepowered:spongegradle:0.8'
         classpath 'org.spongepowered:mixingradle:0.4-SNAPSHOT'
     }
 }


### PR DESCRIPTION
The Gradle build script no longer works since https://github.com/SpongePowered/SpongeCommon/commit/ec0ef6622d1e0a983979fc67221994baddc10512 was pushed. SpongeForge was updated for this (https://github.com/SpongePowered/SpongeForge/commit/742c1fe3059ee0b66fa1b138587fbc95c99e0d81), but SpongeVanilla was not. This updates SpongeGradle to fix it. It also updates shadow to match the SpongeForge version.