### PR TITLE
Add TestPlugin suite for in-development testing

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = name
 include 'SpongeCommon'
 include 'SpongeCommon:SpongeAPI'
+include 'SpongeCommon:testplugins'
 
 def clientGradle = file('client.gradle')
 if (clientGradle.exists()) {


### PR DESCRIPTION
[SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/1411) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/1606) | **SpongeVanilla**
This adds a unique TestPlugins project to SpongeCommon that would allow for implementation and API to be tested in a plugin-like environment.

What this does:
- Adds a "in-dev" plugin that is exposed in development environments that can be used without manually adding plugins back and forth to the module/project dependencies
- Avoids the test plugin output to be included in shadow jars for production jars (source jars and javadoc jars included)
- Allows for future unit testing integration with pre-defined listeners
