### PR TITLE
Implement stats collection config autopopulation

### DIFF
--- a/src/main/java/org/spongepowered/server/SpongeVanilla.java
+++ b/src/main/java/org/spongepowered/server/SpongeVanilla.java
@@ -145,6 +145,7 @@ public final class SpongeVanilla extends MetaPluginContainer {
         SpongeImpl.postState(GameState.INITIALIZATION, SpongeEventFactory.createGameInitializationEvent(Sponge.getCauseStackManager().getCurrentCause()));
 
         this.registry.postInit();
+        SpongeHooks.populatePluginsInStatsConfig();
         SpongeImpl.getConfigSaveManager().flush();
 
         SpongeImpl.postState(GameState.POST_INITIALIZATION, SpongeEventFactory.createGamePostInitializationEvent(Sponge.getCauseStackManager().getCurrentCause()));


### PR DESCRIPTION
[SpongeAPI](https://github.com/SpongePowered/SpongeAPI/pull/1895) | [SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2060) | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/2382) | **SpongeVanilla** | [Original Issue](https://github.com/SpongePowered/SpongeAPI/issues/1862)

This simply populates the statistics-collection config with the default on startup

**This PR is not for discussion of whether stats are bad or not, Sponge's policies, or any general gripe. This is simply the proposed implementation of the API. Please leave drama out of this PR, thanks.**