### PR TITLE
Update Versioning Strings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,13 @@ buildscript {
     }
 }
 
+ext.implementationId = "spongevanilla"
 // Apply shared implementation Gradle config
 apply from: project(':SpongeCommon').file('gradle/implementation.gradle')
 apply plugin: 'de.sebastianboegl.shadow.transformer.log4j'
 
-version = "$minecraft.version-$apiSuffix-$buildNumber"
+version = "$minecraft.version-$implementationVersion"
+System.err.println(version)
 
 minecraft {
     tweakClass = 'org.spongepowered.server.launch.VanillaServerTweaker'

--- a/src/main/java/org/spongepowered/server/SpongeVanilla.java
+++ b/src/main/java/org/spongepowered/server/SpongeVanilla.java
@@ -55,6 +55,7 @@ import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.api.service.sql.SqlService;
 import org.spongepowered.common.SpongeBootstrap;
 import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.common.SpongeImplHooks;
 import org.spongepowered.common.SpongeInternalListeners;
 import org.spongepowered.common.entity.ai.SpongeEntityAICommonSuperclass;
 import org.spongepowered.common.inject.SpongeGuice;
@@ -76,6 +77,7 @@ import org.spongepowered.server.launch.plugin.PluginSource;
 import org.spongepowered.server.plugin.MetaPluginContainer;
 import org.spongepowered.server.plugin.MetadataContainer;
 import org.spongepowered.server.plugin.MinecraftPluginContainer;
+import org.spongepowered.server.plugin.SpongeCommonContainer;
 import org.spongepowered.server.plugin.VanillaPluginManager;
 
 import java.io.File;
@@ -93,7 +95,7 @@ public final class SpongeVanilla extends MetaPluginContainer {
 
     @Inject
     public SpongeVanilla(MetadataContainer metadata, Logger logger, Game game, SpongeGameRegistry registry) {
-        super(metadata.get(SpongeImpl.ECOSYSTEM_ID, "SpongeVanilla"), PluginSource.find(SpongeVanilla.class));
+        super(metadata.get(SpongeImplHooks.getImplementationId(), "SpongeVanilla"), PluginSource.find(SpongeVanilla.class));
 
         this.logger = logger;
         this.game = game;
@@ -189,6 +191,7 @@ public final class SpongeVanilla extends MetaPluginContainer {
 
         // Register Minecraft plugin container
         MinecraftPluginContainer.register();
+        SpongeCommonContainer.register();
 
         OptionSet options = VanillaCommandLine.parse(args);
 

--- a/src/main/java/org/spongepowered/server/mixin/core/common/MixinSpongeImplHooks.java
+++ b/src/main/java/org/spongepowered/server/mixin/core/common/MixinSpongeImplHooks.java
@@ -81,4 +81,17 @@ public abstract class MixinSpongeImplHooks {
         }).orElse("unknown");
     }
 
+    /**
+     * @author gabizou - October 9th, 2018
+     * @reason Since the common implementation does not know
+     * what type of ecosystem this is, we have to overwrite it
+     * to return the correct ecosystem id, while sponge common
+     * keeps "sponge".
+     * @return This implementation's ecosystem id.
+     */
+    @Overwrite
+    public static String getImplementationId() {
+        return "spongevanilla";
+    }
+
 }

--- a/src/main/java/org/spongepowered/server/plugin/SpongeCommonContainer.java
+++ b/src/main/java/org/spongepowered/server/plugin/SpongeCommonContainer.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.server.plugin;
+
+import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.common.SpongeImpl;
+import org.spongepowered.plugin.meta.PluginMetadata;
+import org.spongepowered.server.launch.plugin.PluginSource;
+
+public class SpongeCommonContainer {
+
+
+    public static void register() {
+        SpongeImpl.setSpongePlugin(create());
+    }
+
+    private static PluginContainer create() {
+        MetadataContainer metadata = MetadataContainer.load("");
+        PluginMetadata meta = metadata.get(SpongeImpl.ECOSYSTEM_ID, SpongeImpl.ECOSYSTEM_NAME);
+        return new MetaPluginContainer(meta, PluginSource.find(SpongeImpl.class));
+    }
+}

--- a/src/main/java/org/spongepowered/server/plugin/VanillaPluginManager.java
+++ b/src/main/java/org/spongepowered/server/plugin/VanillaPluginManager.java
@@ -68,6 +68,7 @@ public class VanillaPluginManager implements PluginManager {
         this.rootInjector = injector.getParent();
 
         this.registerPlugin(SpongeImpl.getMinecraftPlugin());
+        this.registerPlugin(SpongeImpl.getSpongePlugin());
         this.registerPlugin(metadata.createContainer(Platform.API_ID, SpongeImpl.API_NAME, impl.getSource()));
         this.registerPlugin(impl);
         this.registerPlugin(metadata.createContainer("mcp", "Mod Coder Pack", impl.getSource()));


### PR DESCRIPTION
[SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2116) | **SpongeVanilla** | [SpongeForge](https://github.com/SpongePowered/SpongeForge/pull/2472)
To sumarize https://github.com/SpongePowered/SpongeForge/issues/2367:

We are changing our versioning string format for SpongeForge, SpongeVanilla, SpongeCommon, and SpongeAPI.

Because SpongeAPI 7.1.0 has already been released, we will not be making the change to drop the `patchVersion` of the API until API 8.

As of right now however, SpongeCommon has a full blown PluginContainer provided by both implementations (implemented slightly differently due to one having complete control over plugin containers and the other, well, not so much).

Looking for feedback from @Minecrell and others to maybe improve these changes so they're not so ~~janky~~ cluttered.

This particular implementation functions as it should under local production testing and in development testing.