### PR TITLE
Avoid crashing on invalid Plugin annotations

### DIFF
--- a/src/main/java/org/spongepowered/server/launch/plugin/asm/DependencyAnnotationVisitor.java
+++ b/src/main/java/org/spongepowered/server/launch/plugin/asm/DependencyAnnotationVisitor.java
@@ -57,19 +57,19 @@ final class DependencyAnnotationVisitor extends WarningAnnotationVisitor {
         switch (name) {
             case "id":
                 if (!(value instanceof String)) {
-                    throw new InvalidPluginException("Plugin annotation has invalid element 'id'");
+                    throw new InvalidPluginException("Dependency annotation has invalid element 'id'");
                 }
                 this.id = (String) value;
                 return;
             case "version":
                 if (!(value instanceof String)) {
-                    throw new InvalidPluginException("Plugin annotation has invalid element 'version'");
+                    throw new InvalidPluginException("Dependency annotation has invalid element 'version'");
                 }
                 this.version = (String) value;
                 return;
             case "optional":
                 if (!(value instanceof Boolean)) {
-                    throw new InvalidPluginException("Plugin annotation has invalid element 'optional'");
+                    throw new InvalidPluginException("Dependency annotation has invalid element 'optional'");
                 }
                 this.optional = (boolean) value;
                 return;

--- a/src/main/java/org/spongepowered/server/launch/plugin/asm/DependencyAnnotationVisitor.java
+++ b/src/main/java/org/spongepowered/server/launch/plugin/asm/DependencyAnnotationVisitor.java
@@ -29,6 +29,7 @@ import static org.objectweb.asm.Opcodes.ASM5;
 
 import org.spongepowered.plugin.meta.PluginDependency;
 import org.spongepowered.plugin.meta.PluginMetadata;
+import org.spongepowered.server.launch.plugin.InvalidPluginException;
 
 import javax.annotation.Nullable;
 
@@ -55,12 +56,21 @@ final class DependencyAnnotationVisitor extends WarningAnnotationVisitor {
         checkNotNull(name, "name");
         switch (name) {
             case "id":
+                if (!(value instanceof String)) {
+                    throw new InvalidPluginException("Plugin annotation has invalid element 'id'");
+                }
                 this.id = (String) value;
                 return;
             case "version":
+                if (!(value instanceof String)) {
+                    throw new InvalidPluginException("Plugin annotation has invalid element 'version'");
+                }
                 this.version = (String) value;
                 return;
             case "optional":
+                if (!(value instanceof Boolean)) {
+                    throw new InvalidPluginException("Plugin annotation has invalid element 'optional'");
+                }
                 this.optional = (boolean) value;
                 return;
             default:

--- a/src/main/java/org/spongepowered/server/launch/plugin/asm/PluginAnnotationVisitor.java
+++ b/src/main/java/org/spongepowered/server/launch/plugin/asm/PluginAnnotationVisitor.java
@@ -66,7 +66,7 @@ final class PluginAnnotationVisitor extends WarningAnnotationVisitor {
         }
 
         if (name == null) {
-            throw new InvalidPluginException("Plugin annotation has null element");
+            throw new InvalidPluginException("Plugin annotation attribute name is null");
         }
 
         if (this.state == State.DEPENDENCIES) {

--- a/src/main/java/org/spongepowered/server/launch/plugin/asm/PluginAnnotationVisitor.java
+++ b/src/main/java/org/spongepowered/server/launch/plugin/asm/PluginAnnotationVisitor.java
@@ -24,10 +24,8 @@
  */
 package org.spongepowered.server.launch.plugin.asm;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.objectweb.asm.Opcodes.ASM5;
 
-import com.google.common.base.Preconditions;
 import org.objectweb.asm.AnnotationVisitor;
 import org.spongepowered.plugin.meta.PluginMetadata;
 import org.spongepowered.server.launch.plugin.InvalidPluginException;
@@ -57,34 +55,54 @@ final class PluginAnnotationVisitor extends WarningAnnotationVisitor {
         return "@Plugin";
     }
 
-    private void checkState(State state) {
-        Preconditions.checkState(this.state == state, "Expected state %s, but is %s", state, this.state);
-    }
-
     @Override
     public void visit(String name, Object value) {
         if (this.state == State.AUTHORS) {
+            if (!(value instanceof String)) {
+                throw new InvalidPluginException("Plugin annotation has invalid element 'author'");
+            }
             this.metadata.addAuthor((String) value);
             return;
         }
 
-        checkState(State.DEFAULT);
-        checkNotNull(name, "name");
+        if (name == null) {
+            throw new InvalidPluginException("Plugin annotation has null element");
+        }
+
+        if (this.state == State.DEPENDENCIES) {
+            throw new InvalidPluginException("Plugin annotation has invalid element 'dependencies'");
+        }
+
         switch (name) {
             case "id":
+                if (!(value instanceof String)) {
+                    throw new InvalidPluginException("Plugin annotation has invalid element 'id'");
+                }
                 this.hasId = true;
                 this.metadata.setId((String) value);
                 return;
             case "name":
+                if (!(value instanceof String)) {
+                    throw new InvalidPluginException("Plugin annotation has invalid element 'name'");
+                }
                 this.metadata.setName((String) value);
                 return;
             case "version":
+                if (!(value instanceof String)) {
+                    throw new InvalidPluginException("Plugin annotation has invalid element 'version'");
+                }
                 this.metadata.setVersion((String) value);
                 return;
             case "description":
+                if (!(value instanceof String)) {
+                    throw new InvalidPluginException("Plugin annotation has invalid element 'description'");
+                }
                 this.metadata.setDescription((String) value);
                 return;
             case "url":
+                if (!(value instanceof String)) {
+                    throw new InvalidPluginException("Plugin annotation has invalid element 'url'");
+                }
                 this.metadata.setUrl((String) value);
                 return;
             default:
@@ -102,7 +120,9 @@ final class PluginAnnotationVisitor extends WarningAnnotationVisitor {
 
     @Override
     public AnnotationVisitor visitArray(String name) {
-        checkNotNull(name, "name");
+        if (name == null) {
+            throw new InvalidPluginException("Plugin annotation has null element");
+        }
         switch (name) {
             case "authors":
                 this.state = State.AUTHORS;


### PR DESCRIPTION
An `InvalidPluginException` is thrown, the plugin is skipped and the exception printed.
I think I've covered every possible case.

Fix https://github.com/SpongePowered/SpongeVanilla/issues/373

