### PR TITLE
Fix NoSuchMethodException

### DIFF
--- a/src/main/java/org/spongepowered/server/SpongeVanilla.java
+++ b/src/main/java/org/spongepowered/server/SpongeVanilla.java
@@ -120,7 +120,7 @@ public final class SpongeVanilla extends MetaPluginContainer {
             try {
                 // Workaround until we can have static mixin accessors.
                 final String registerName = SpongeImplHooks.isDeobfuscatedEnvironment() ? "register" : "func_191303_a";
-                Method register = EntityList.class.getMethod(registerName, int.class, String.class, Class.class, String.class);
+                Method register = EntityList.class.getDeclaredMethod(registerName, int.class, String.class, Class.class, String.class);
                 register.setAccessible(true);
                 register.invoke(null, registration.id, registration.name.toString(), registration.type, registration.oldName);
             } catch (Exception e) {


### PR DESCRIPTION
This PR fixes a NoSuchMethodException error that appears during server startup due to an attempt to get a private method using `getMethod` instead of `getDeclaredMethod`

```
java.lang.NoSuchMethodException: net.minecraft.entity.EntityList.func_191303_a(int, java.lang.String, java.lang.Class, java.lang.String)
     at java.lang.Class.getMethod(Class.java:1786)
     at org.spongepowered.server.SpongeVanilla.preInitialize(SpongeVanilla.java:123)
     at net.minecraft.server.dedicated.DedicatedServer.handler$vanilla$onServerLoad$zpb000(SourceFile:1735)
     at net.minecraft.server.dedicated.DedicatedServer.func_71197_b(SourceFile:117)
     at net.minecraft.server.MinecraftServer.run(SourceFile:434)
     at java.lang.Thread.run(Thread.java:748)
```