### PR TITLE
Migrate several patches to SV since they're now in Forge proper.

### DIFF
--- a/src/main/java/org/spongepowered/server/mixin/exploit/ChunkMixin_AssuredChangesMarkedDirty.java
+++ b/src/main/java/org/spongepowered/server/mixin/exploit/ChunkMixin_AssuredChangesMarkedDirty.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.server.mixin.exploit;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.ClassInheritanceMultiMap;
+import net.minecraft.world.chunk.Chunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Chunk.class)
+public abstract class ChunkMixin_AssuredChangesMarkedDirty {
+
+    @Shadow public abstract void markDirty();
+
+    /**
+     * @author Aikar - July 23rd, 2018
+     * @reason Mark chunk dirty any time entities change to guarantee it saves.
+     *
+     * @see <html>https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0306-Mark-chunk-dirty-anytime-entities-change-to-guarante.patch</html>
+     *
+     * @param entityIn The entity being added
+     * @param ci The callback
+     */
+    @Inject(method = "addEntity", at = @At("TAIL"))
+    private void assureMarkedDirty$markDirtyOnEntityAdd(final Entity entityIn, final CallbackInfo ci) {
+        this.markDirty();
+    }
+
+    /**
+     * @author Aikar - July 23rd, 2018
+     * @reason Mark chunk dirty any time entities change to guarantee it saves.
+     *
+     * @see <html>https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0306-Mark-chunk-dirty-anytime-entities-change-to-guarante.patch</html>
+     *
+     * @param map The map being removed from
+     * @param entity The entity being removed
+     */
+    @SuppressWarnings({"SuspiciousMethodCalls", "rawtypes"})
+    @Redirect(method = "removeEntityAtIndex",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/util/ClassInheritanceMultiMap;remove(Ljava/lang/Object;)Z"))
+    private boolean assureMarkedDirty$ifEntityRemoveMarkDirty(final ClassInheritanceMultiMap map, final Object entity) {
+        if (map.remove(entity)) {
+            this.markDirty();
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/org/spongepowered/server/mixin/exploit/EntityLeashKnotMixin_ProcessChunkOnMove.java
+++ b/src/main/java/org/spongepowered/server/mixin/exploit/EntityLeashKnotMixin_ProcessChunkOnMove.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.server.mixin.exploit;
+
+import net.minecraft.entity.EntityLeashKnot;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityLeashKnot.class)
+public abstract class EntityLeashKnotMixin_ProcessChunkOnMove extends EntityMixin_ProcessChunkOnMove {
+
+    /**
+     * @author Aikar - July 29th, 2018
+     * @reason Always process chunk registration after moving.
+     * This will help guarantee that entities are always in
+     * the chunk that they are currently located at.
+     *
+     * @see <html>https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0315-Always-process-chunk-registration-after-moving.patch</html>
+     *
+     * @param ci callback info
+     */
+    @Inject(method = "updateBoundingBox", at = @At("TAIL"))
+    private void processChunkOnMove$onUpdateBoundingBoxUpdateWorld(final CallbackInfo ci) {
+        if (this.bridge$isWorldTracked() && !this.world.isRemote) {
+            this.world.updateEntityWithOptionalForce((EntityLeashKnot) (Object) this, false);
+        }
+    }
+
+}

--- a/src/main/java/org/spongepowered/server/mixin/exploit/EntityMixin_ChunkLoadOnPositionSet.java
+++ b/src/main/java/org/spongepowered/server/mixin/exploit/EntityMixin_ChunkLoadOnPositionSet.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.server.mixin.exploit;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.bridge.entity.EntityBridge;
+import org.spongepowered.common.bridge.world.WorldBridge;
+
+/**
+ * A variety of exploit patches that are pulled from Paper that directly
+ * intermixes a few fixes (patches) as one bundle due to their interconnected
+ * nature.
+ */
+@Mixin(Entity.class)
+public abstract class EntityMixin_ChunkLoadOnPositionSet implements EntityBridge {
+
+    @Shadow public World world;
+
+    @Shadow public abstract void setPosition(double x, double y, double z);
+
+    /**
+     * @author Aikar - August 16th, 2018
+     * @reason Player Movement, Entity Creation, and Teleportation move
+     * entities with a very "You are here, no debate" change, making
+     * the server register them as there, regardless if the chunk was
+     * loaded or not.
+     *
+     * It appears possible that with hack clients and lag, a player
+     * may be able to move fast enough to move into an unloaded chunk
+     * and get into a buggy state.
+     *
+     * To prevent this, we will ensure a chunk is always loaded,
+     * guaranteeing that the entity will be properly registered
+     * into its new home comfortably.
+     *
+     * Permission by Aikar to have ported this patch along with other
+     * patches for the Sponge project.
+     * @see <html>https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0335-Ensure-chunks-are-always-loaded-on-hard-position-set.patch</html>
+     *
+     * @param entity This entity (this)
+     * @param x The x location (this.posX)
+     * @param y The y location (this.posY)
+     * @param z The z location (this.posZ)
+     */
+    @Redirect(
+        method = "setPositionAndRotation",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/entity/Entity;setPosition(DDD)V"
+        )
+    )
+    private void chunkLoadPositionReset$onSetPositionMarkWorldChunkAsLoaded(final Entity entity, final double x, final double y, final double z) {
+        // Sponge - Make sure the chunk is marked as loaded
+        if (!((WorldBridge) this.world).bridge$isFake()) {
+            this.world.getChunk((int) Math.floor(x) >> 4, (int) Math.floor(z) >> 4);
+        }
+        // then continue to set the position
+        this.setPosition(x, y, z);
+    }
+
+}

--- a/src/main/java/org/spongepowered/server/mixin/exploit/EntityMixin_ProcessChunkOnMove.java
+++ b/src/main/java/org/spongepowered/server/mixin/exploit/EntityMixin_ProcessChunkOnMove.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.server.mixin.exploit;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.common.bridge.entity.EntityBridge;
+
+@Mixin(Entity.class)
+public abstract class EntityMixin_ProcessChunkOnMove implements EntityBridge {
+
+    @Shadow public World world;
+
+    /**
+     * @author Aikar - July 29th, 2018
+     * @reason Always process chunk registration after moving.
+     * This will help guarantee that entities are always in the
+     * chunk that they are currently located at.
+     *
+     * @see <html>https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0315-Always-process-chunk-registration-after-moving.patch</html>
+     *
+     * @param x The x position
+     * @param y The y position
+     * @param z The z position
+     * @param ci The callback info
+     */
+    @Inject(method = "setPosition", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/Entity;width:F"))
+    private void processChunkOnMove$onSetPositionEnsureWorldChunkNoticed(final double x, final double y, final double z, final CallbackInfo ci) {
+        if (this.bridge$isWorldTracked() && !this.world.isRemote) {
+            // We want to not force an update, this just forces the world to update the tracked entity lists
+            // and the chunks containing entities.
+            this.world.updateEntityWithOptionalForce((net.minecraft.entity.Entity) (Object) this, false);
+        }
+    }
+
+    /**
+     * @author Aikar - July 29th, 2018
+     * @reason Always process chunk registration after moving.
+     * This will help guarantee that entities are always in the
+     * chunk that they are currently located at.
+     *
+     * @see <html>https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0315-Always-process-chunk-registration-after-moving.patch</html>
+     *
+     * @param ci The callback info
+     */
+    @Inject(method = "resetPositionToBB", at = @At("TAIL"))
+    private void processChunkOnMove$onResizeVerifyEntityInWorld(final CallbackInfo ci) {
+        // Check if the entity is actively being tracked.
+        if (this.bridge$isWorldTracked() && !this.world.isRemote) {
+            // We want to not force an update, this just forces the world to update the tracked entity lists
+            // and the chunks containing entities.
+            this.world.updateEntityWithOptionalForce((net.minecraft.entity.Entity) (Object) this, false);
+        }
+    }
+
+}

--- a/src/main/java/org/spongepowered/server/mixin/exploit/EntityShulkerMixin_ProcessChunkOnMove.java
+++ b/src/main/java/org/spongepowered/server/mixin/exploit/EntityShulkerMixin_ProcessChunkOnMove.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.server.mixin.exploit;
+
+import net.minecraft.entity.monster.EntityShulker;
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityShulker.class)
+public abstract class EntityShulkerMixin_ProcessChunkOnMove extends EntityMixin_ProcessChunkOnMove {
+
+    /**
+     * @author Aikar - July 29th, 2018
+     * @reason Always process chunk registration after moving.
+     * This will help guarantee that entities are always in the
+     * chunk that they are currently located at.
+     *
+     * @see <html>https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0315-Always-process-chunk-registration-after-moving.patch</html>
+     *
+     * @param ci The callback info
+     */
+    @Inject(
+        method = "onUpdate",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/entity/monster/EntityShulker;posZ:D",
+            opcode = Opcodes.PUTFIELD,
+            shift = At.Shift.AFTER
+        )
+    )
+    private void processChunkOnMove$onUpdatePositionMarkUpdatedPositionInTrackedWorld(final CallbackInfo ci) {
+        if (this.bridge$isWorldTracked() && !this.world.isRemote) {
+            this.world.updateEntityWithOptionalForce((EntityShulker) (Object) this, false);
+        }
+    }
+}

--- a/src/main/java/org/spongepowered/server/mixin/exploit/NetHandlerPlayServerMixin_LimitBookSize.java
+++ b/src/main/java/org/spongepowered/server/mixin/exploit/NetHandlerPlayServerMixin_LimitBookSize.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.server.mixin.exploit;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.network.NetHandlerPlayServer;
+import org.spongepowered.api.network.PlayerConnection;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.common.SpongeImpl;
+
+@Mixin(NetHandlerPlayServer.class)
+public abstract class NetHandlerPlayServerMixin_LimitBookSize {
+
+    /**
+     * @author Aaron1011 - January 31, 2019
+     * @reason Prevents clients from sending excessively large book, avoiding
+     * a chunk corruption/dupe issue
+     *
+     * @see <html>https://github.com/PaperMC/Paper/blob/f8058a8187da9f6185d95bb786783e12c79c8b18/Spigot-Server-Patches/0403-Book-Size-Limits.patch</html>
+     */
+    @Redirect(method = "processCustomPayload",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemWritableBook;isNBTValid(Lnet/minecraft/nbt/NBTTagCompound;)Z"))
+    private boolean limitBookSize$onIsNBTValid(NBTTagCompound bookData) {
+        NBTTagList pageList = bookData.getTagList("pages", 8);
+        long byteTotal = 0;
+        int maxBookPageSize = SpongeImpl.getGlobalConfigAdapter().getConfig().getExploits().getMaxBookPageSize();
+        double multiplier = Math.max(0.3D, Math.min(1D, SpongeImpl.getGlobalConfigAdapter().getConfig().getExploits().getBookSizeTotalMultiplier()));
+        long byteAllowed = maxBookPageSize;
+        for (int i = 0; i < pageList.tagCount(); ++i) {
+            String testString = pageList.getStringTagAt(i);
+            int byteLength = testString.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
+            byteTotal += byteLength;
+            int length = testString.length();
+            int multibytes = 0;
+            if (byteLength != length) {
+                for (char c : testString.toCharArray()) {
+                    if (c > 127) {
+                        multibytes++;
+                    }
+                }
+            }
+            byteAllowed += (maxBookPageSize * Math.min(1, Math.max(0.1D, (double) length / 255D))) * multiplier;
+
+            if (multibytes > 1) {
+                // penalize MB
+                byteAllowed -= multibytes;
+            }
+        }
+
+        if (byteTotal > byteAllowed) {
+            SpongeImpl.getLogger().error(((PlayerConnection) this).getPlayer().getName() + " tried to send too large of a book. Book Size: " + byteTotal + " - Allowed:  "+ byteAllowed + " - Pages: " + pageList.tagCount());
+            SpongeImpl.getServer().addScheduledTask(() -> {
+                ((PlayerConnection) this).getPlayer().kick(Text.of("Book too large!"));
+            });
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/org/spongepowered/server/mixin/exploit/NetHandlerPlayServerMixin_PlayerVehiclesSyncPatch.java
+++ b/src/main/java/org/spongepowered/server/mixin/exploit/NetHandlerPlayServerMixin_PlayerVehiclesSyncPatch.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of Sponge, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.server.mixin.exploit;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.NetHandlerPlayServer;
+import net.minecraft.network.play.client.CPacketVehicleMove;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+@Mixin(value = NetHandlerPlayServer.class)
+public class NetHandlerPlayServerMixin_PlayerVehiclesSyncPatch {
+
+    @Shadow public EntityPlayerMP player;
+
+    /**
+     * @author Aikar - September 21st, 2018
+     * @reason Player positions could become desynced with their vehicle
+     * resulting in chunk conflicts about which chunk the entity should
+     * really be in.
+     *
+     * @see <html>https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0378-Sync-Player-Position-to-Vehicles.patch</html>
+     *
+     * @param entity The entity (lowest vehicle being ridden)
+     * @param x The x position being moved to
+     * @param y The y position being moved to
+     * @param z The z position being moved to
+     * @param yaw The yaw
+     * @param pitch The pitch
+     * @param packetVehicleMove The vehicle move packet
+     */
+    @Redirect(
+        method = "processVehicleMove",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/entity/Entity;setPositionAndRotation(DDDFF)V"
+        ),
+        slice = @Slice(
+            from = @At(
+                value = "INVOKE",
+                target = "Lnet/minecraft/entity/Entity;move(Lnet/minecraft/entity/MoverType;DDD)V"
+            ),
+            to = @At(
+                value = "INVOKE",
+                target = "Lnet/minecraft/util/math/AxisAlignedBB;shrink(D)Lnet/minecraft/util/math/AxisAlignedBB;",
+                ordinal = 1
+            )
+        )
+    )
+    private void playerSyncVehicleImpl$onPlayerSetLocationReSyncVehicle(final Entity entity, final double x, final double y, final double z,
+        final float yaw, final float pitch, final CPacketVehicleMove packetVehicleMove) {
+        entity.setPositionAndRotation(x, y, z, yaw, pitch);
+        // Now set the location on the player to update ridden entities and the position in the world.
+        this.player.setPositionAndRotation(x, y, z, yaw, pitch);
+
+    }
+
+    /**
+     * @author Aikar - September 21st, 2018
+     * @reason Player positions could become desynced with their vehicle
+     * resulting in chunk conflicts about which chunk the entity should
+     * really be in.
+     *
+     * @see <html>https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0378-Sync-Player-Position-to-Vehicles.patch</html>
+     *
+     * @param entity The entity (lowest vehicle being ridden)
+     * @param x The x position being moved to
+     * @param y The y position being moved to
+     * @param z The z position being moved to
+     * @param yaw The yaw
+     * @param pitch The pitch
+     */
+    @Redirect(
+        method = "processVehicleMove",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/entity/Entity;setPositionAndRotation(DDDFF)V"
+        ),
+        slice = @Slice(
+            from = @At(
+                value = "INVOKE",
+                target = "Ljava/util/List;isEmpty()Z",
+                ordinal = 1,
+                remap = false
+            ),
+            to = @At(
+                value = "INVOKE",
+                target = "Lnet/minecraft/network/play/server/SPacketMoveVehicle;<init>(Lnet/minecraft/entity/Entity;)V",
+                ordinal = 1
+            )
+        )
+    )
+    private void playerSyncVehicleImpl$onEntitySetRotationIfCancelled(final Entity entity, final double x, final double y, final double z,
+        final float yaw, final float pitch) {
+        entity.setPositionAndRotation(x, y, z, yaw, pitch);
+        // then set the player again
+        this.player.setPositionAndRotation(x, y, z, yaw, pitch);
+    }
+}

--- a/src/main/resources/mixins.vanilla.exploit.json
+++ b/src/main/resources/mixins.vanilla.exploit.json
@@ -1,0 +1,20 @@
+{
+    "minVersion": "0.7.10",
+    "package": "org.spongepowered.server.mixin.exploit",
+    "refmap": "mixins.vanilla.refmap.json",
+    "plugin": "org.spongepowered.common.mixin.plugin.ExploitPlugin",
+    "target": "@env(DEFAULT)",
+    "compatibilityLevel": "JAVA_8",
+    "mixins": [
+        "ChunkMixin_AssuredChangesMarkedDirty",
+        "EntityLeashKnotMixin_ProcessChunkOnMove",
+        "EntityMixin_ChunkLoadOnPositionSet",
+        "EntityMixin_ProcessChunkOnMove",
+        "EntityShulkerMixin_ProcessChunkOnMove",
+        "NetHandlerPlayServerMixin_LimitBookSize",
+        "NetHandlerPlayServerMixin_PlayerVehiclesSyncPatch"
+    ],
+    "injectors": {
+        "defaultRequire": 1
+    }
+}


### PR DESCRIPTION
[SpongeCommon](https://github.com/SpongePowered/SpongeCommon/pull/2399) | **SpongeVanilla**

All these patches were added to Forge just over a year ago in MinecraftForge/MinecraftForge#5160, so they no longer need to be applied to Forge.

Note that the configuration options are still available on Forge. Not sure whether they should be marked as SpongeVanilla-only.

Fixes SpongePowered/SpongeForge#3003.