### PR TITLE
Fix shutdown inconsistencies with SpongeForge

### DIFF
--- a/src/main/java/org/spongepowered/server/mixin/core/server/MinecraftServerMixin_Vanilla.java
+++ b/src/main/java/org/spongepowered/server/mixin/core/server/MinecraftServerMixin_Vanilla.java
@@ -176,6 +176,8 @@ public abstract class MinecraftServerMixin_Vanilla implements MinecraftServerBri
                     }
 
                     WorldManager.unloadWorld(worldserver1, false, true);
+                    // Sponge End
+                    worldserver1.flush();
                 }
             }
 

--- a/src/main/java/org/spongepowered/server/mixin/core/server/MinecraftServerMixin_Vanilla.java
+++ b/src/main/java/org/spongepowered/server/mixin/core/server/MinecraftServerMixin_Vanilla.java
@@ -185,6 +185,11 @@ public abstract class MinecraftServerMixin_Vanilla implements MinecraftServerBri
         }
     }
 
+    @Inject(method = "run", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;systemExitNow()V"))
+    private void vanilla$callServerStopped(CallbackInfo ci) throws Exception {
+        vanilla$spongeVanilla.onServerStopped();
+    }
+
     @Override
     public long[] bridge$getWorldTickTimes(int dimensionId) {
         return this.vanilla$worldTickTimes.get(dimensionId);

--- a/src/main/java/org/spongepowered/server/mixin/core/server/dedicated/DedicatedServerMixin_Vanilla.java
+++ b/src/main/java/org/spongepowered/server/mixin/core/server/dedicated/DedicatedServerMixin_Vanilla.java
@@ -108,9 +108,4 @@ public abstract class DedicatedServerMixin_Vanilla extends MinecraftServer {
         vanilla$scheduler.tickSyncScheduler();
     }
 
-    @Inject(method = "systemExitNow", at = @At(value = "HEAD"))
-    private void vanilla$callServerStopped(CallbackInfo ci) throws Exception {
-        vanilla$spongeVanilla.onServerStopped();
-    }
-
 }


### PR DESCRIPTION
This PR fixes two inconsistencies with SpongeForge when shutting down the server:
- `GameStoppedServerEvent` was fired after `GameStoppingEvent`. It's the opposite on SpongeForge.
- World data was not flushed when stopping the server. This kept the files opened and plugins couldn't modify them.